### PR TITLE
Add htmltest

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Links
 2. [**gor**](https://github.com/wendal/gor) ★472
 3. [**Ink**](https://github.com/InkProject/ink) ★336
 4. [**gostatic**](https://github.com/piranha/gostatic) ★298
+5. [**htmltest**](https://github.com/wjdp/htmltest) ★20 _tool_
 
 Links
 


### PR DESCRIPTION
It's a testing tool so doesn't quite feel it belongs with the actual static site generators. Perhaps a separate section would be better?